### PR TITLE
hotfix | self invoke imtd batching

### DIFF
--- a/lib/functions/imtd-process.js
+++ b/lib/functions/imtd-process.js
@@ -75,12 +75,15 @@ async function getData (stationId) {
 
 async function getRloiIds ({ limit, offset } = {}) {
   try {
-    return await pg('rivers_mview')
+    logger.info(`Retrieving up to ${limit} rloi_ids with an offset of ${offset}`)
+    const result = await pg('rivers_mview')
       .distinct('rloi_id')
       .whereNotNull('rloi_id')
       .orderBy('rloi_id', 'asc')
       .limit(limit)
       .offset(offset)
+    logger.info(`Retrieved ${result.length} rloi_ids`)
+    return result
   } catch (error) {
     throw Error(`Could not get list of id's from database (Error: ${error.message})`)
   }
@@ -99,9 +102,13 @@ async function handler ({ offset = 0 } = {}) {
 
   pg.destroy()
 
-  if (stations.length === BATCH_SIZE) {
-    await invokeLambda(process.env.AWS_LAMBDA_FUNCTION_NAME, {
-      offset: offset + BATCH_SIZE
+  if (stations.length >= BATCH_SIZE) {
+    const functionName = process.env.AWS_LAMBDA_FUNCTION_NAME
+    const newOffset = offset + BATCH_SIZE
+    logger.info(`Invoking ${functionName} with an offset of ${newOffset}`)
+
+    await invokeLambda(functionName, {
+      offset: newOffset
     })
   }
 }

--- a/lib/functions/imtd-process.js
+++ b/lib/functions/imtd-process.js
@@ -92,8 +92,6 @@ async function getRloiIds ({ limit, offset } = {}) {
 async function handler ({ offset = 0 } = {}) {
   const BATCH_SIZE = parseInt(process.env.IMTD_BATCH_SIZE || '500')
 
-  await pg.initialize()
-
   const stations = await getRloiIds({
     offset,
     limit: BATCH_SIZE
@@ -102,8 +100,6 @@ async function handler ({ offset = 0 } = {}) {
   for (const station of stations) {
     await getData(station.rloi_id)
   }
-
-  await pg.destroy()
 
   if (stations.length >= BATCH_SIZE) {
     const functionName = process.env.AWS_LAMBDA_FUNCTION_NAME
@@ -117,3 +113,9 @@ async function handler ({ offset = 0 } = {}) {
 }
 
 module.exports.handler = handler
+
+process.on('SIGTERM', async () => {
+  logger.info('SIGTERM received, destroying DB connection')
+  await pg.destroy()
+  process.exit(0)
+})

--- a/lib/functions/imtd-process.js
+++ b/lib/functions/imtd-process.js
@@ -91,6 +91,9 @@ async function getRloiIds ({ limit, offset } = {}) {
 
 async function handler ({ offset = 0 } = {}) {
   const BATCH_SIZE = parseInt(process.env.IMTD_BATCH_SIZE || '500')
+
+  await pg.initialize()
+
   const stations = await getRloiIds({
     offset,
     limit: BATCH_SIZE

--- a/lib/functions/imtd-process.js
+++ b/lib/functions/imtd-process.js
@@ -100,7 +100,7 @@ async function handler ({ offset = 0 } = {}) {
     await getData(station.rloi_id)
   }
 
-  pg.destroy()
+  await pg.destroy()
 
   if (stations.length >= BATCH_SIZE) {
     const functionName = process.env.AWS_LAMBDA_FUNCTION_NAME

--- a/lib/functions/imtd-process.js
+++ b/lib/functions/imtd-process.js
@@ -2,7 +2,7 @@ const parseThresholds = require('../models/parse-thresholds')
 const axios = require('axios')
 const logger = require('../helpers/logging')
 const pg = require('../helpers/db')
-const directly = require('directly')
+const invokeLambda = require('../helpers/invoke-lambda')
 
 async function deleteThresholds (stationId) {
   try {
@@ -73,32 +73,37 @@ async function getData (stationId) {
   }
 }
 
-async function getRloiIds () {
+async function getRloiIds ({ limit, offset } = {}) {
   try {
     return await pg('rivers_mview')
       .distinct('rloi_id')
       .whereNotNull('rloi_id')
       .orderBy('rloi_id', 'asc')
+      .limit(limit)
+      .offset(offset)
   } catch (error) {
     throw Error(`Could not get list of id's from database (Error: ${error.message})`)
   }
 }
 
-async function handler (_event) {
-  // BATCH_SIZE is a nominal figure and the intent of the use of batching is to
-  // allow parallel requests to the IMTD API without overwhelming the service
-  // In theory, increasing batch size should decrease overall processing time
-  // but in practice it makes no discernible difference possibly because the API
-  // queues requests and processes them one at a time.
-  const BATCH_SIZE = 16
+async function handler ({ offset = 0 } = {}) {
+  const BATCH_SIZE = parseInt(process.env.IMTD_BATCH_SIZE || '500')
+  const stations = await getRloiIds({
+    offset,
+    limit: BATCH_SIZE
+  })
 
-  const stations = await getRloiIds()
+  for (const station of stations) {
+    await getData(station.rloi_id)
+  }
 
-  await directly(BATCH_SIZE, stations.map(s => () => getData(s.rloi_id)))
-
-  // NOTE: need to explicity tear down connection pool
-  // without this, active connections to DB are persisted until they time out
   pg.destroy()
+
+  if (stations.length === BATCH_SIZE) {
+    await invokeLambda(process.env.AWS_LAMBDA_FUNCTION_NAME, {
+      offset: offset + BATCH_SIZE
+    })
+  }
 }
 
 module.exports.handler = handler

--- a/lib/helpers/invoke-lambda.js
+++ b/lib/helpers/invoke-lambda.js
@@ -5,6 +5,6 @@ const lambda = new Lambda()
 module.exports = function invokeLambda (functionName, payload) {
   return lambda.invokeAsync({
     FunctionName: functionName,
-    InvokeArgs: JSON.stringify(payload, null, 2)
+    InvokeArgs: JSON.stringify(payload)
   }).promise()
 }

--- a/lib/helpers/invoke-lambda.js
+++ b/lib/helpers/invoke-lambda.js
@@ -1,0 +1,10 @@
+const { Lambda } = require('aws-sdk')
+
+const lambda = new Lambda()
+
+module.exports = function invokeLambda (functionName, payload) {
+  return lambda.invokeAsync({
+    FunctionName: functionName,
+    Payload: JSON.stringify(payload, null, 2)
+  }).promise()
+}

--- a/lib/helpers/invoke-lambda.js
+++ b/lib/helpers/invoke-lambda.js
@@ -5,6 +5,6 @@ const lambda = new Lambda()
 module.exports = function invokeLambda (functionName, payload) {
   return lambda.invokeAsync({
     FunctionName: functionName,
-    Payload: JSON.stringify(payload, null, 2)
+    InvokeArgs: JSON.stringify(payload, null, 2)
   }).promise()
 }

--- a/test/unit/functions/imtd-process.js
+++ b/test/unit/functions/imtd-process.js
@@ -185,8 +185,8 @@ experiment('imtd processing', () => {
 
       await handler()
       const logInfoCalls = logger.info.getCalls()
-      expect(logInfoCalls.length).to.equal(1)
-      expect(logInfoCalls[0].args[0]).to.equal('Processed 6 thresholds for RLOI id 1001')
+      expect(logInfoCalls.length).to.equal(3)
+      expect(logInfoCalls[2].args[0]).to.equal('Processed 6 thresholds for RLOI id 1001')
     })
   })
 
@@ -199,9 +199,9 @@ experiment('imtd processing', () => {
       await handler()
 
       const logInfoCalls = logger.info.getCalls()
-      expect(logInfoCalls.length).to.equal(2)
-      expect(logInfoCalls[0].args[0]).to.equal('Station 1001 not found (HTTP Status: 404)')
-      expect(logInfoCalls[1].args[0]).to.equal('Deleted thresholds for RLOI id 1001')
+      expect(logInfoCalls.length).to.equal(4)
+      expect(logInfoCalls[2].args[0]).to.equal('Station 1001 not found (HTTP Status: 404)')
+      expect(logInfoCalls[3].args[0]).to.equal('Deleted thresholds for RLOI id 1001')
 
       const logErrorCalls = logger.error.getCalls()
       expect(logErrorCalls.length).to.equal(0)
@@ -250,7 +250,7 @@ experiment('imtd processing', () => {
       await handler()
 
       const logInfoCalls = logger.info.getCalls()
-      expect(logInfoCalls.length).to.equal(1)
+      expect(logInfoCalls.length).to.equal(3)
 
       const logErrorCalls = logger.error.getCalls()
       expect(logErrorCalls.length).to.equal(1)
@@ -290,7 +290,7 @@ experiment('imtd processing', () => {
       expect(returnedError.message).to.equal('Could not get list of id\'s from database (Error: select distinct "rloi_id" from "rivers_mview" where "rloi_id" is not null order by "rloi_id" asc limit $1 - refused)')
 
       const logInfoCalls = logger.info.getCalls()
-      expect(logInfoCalls.length).to.equal(0)
+      expect(logInfoCalls.length).to.equal(1)
 
       const logErrorCalls = logger.error.getCalls()
       expect(logErrorCalls.length).to.equal(0)
@@ -327,7 +327,7 @@ experiment('imtd processing', () => {
       expect(logErrorCalls[1].args[0]).to.equal('Could not process data for station 1001 (delete from "station_imtd_threshold" where "station_id" = $1 - Delete Fail)')
 
       const logInfoCalls = logger.info.getCalls()
-      expect(logInfoCalls.length).to.equal(0)
+      expect(logInfoCalls.length).to.equal(2)
     })
     test('it should log an error when DB connection fails when deleting thresholds when there are no thresholds to insert', async () => {
       tracker.on('query', function (query, step) {
@@ -353,7 +353,7 @@ experiment('imtd processing', () => {
       expect(logErrorCalls[1].args[0]).to.equal('Could not process data for station 1001 (delete from "station_imtd_threshold" where "station_id" = $1 - Delete Fail)')
 
       const logInfoCalls = logger.info.getCalls()
-      expect(logInfoCalls.length).to.equal(0)
+      expect(logInfoCalls.length).to.equal(2)
     })
     test('it should log an error and rollback when DB connection fails when inserting thresholds', async () => {
       tracker.on('query', function (query, step) {
@@ -391,7 +391,7 @@ experiment('imtd processing', () => {
       expect(logErrorCalls[1].args[0]).to.equal('Could not process data for station 1001 (insert into "station_imtd_threshold" ("direction", "fwis_code", "fwis_type", "station_id", "threshold_type", "value") values ($1, $2, $3, $4, $5, $6), ($7, $8, $9, $10, $11, $12), ($13, $14, $15, $16, $17, $18), ($19, $20, $21, $22, $23, $24), ($25, $26, $27, $28, $29, $30), ($31, $32, $33, $34, $35, $36) - Insert Fail)')
 
       const logInfoCalls = logger.info.getCalls()
-      expect(logInfoCalls.length).to.equal(0)
+      expect(logInfoCalls.length).to.equal(2)
     })
   })
 })

--- a/test/unit/helpers/invoke-lambda.js
+++ b/test/unit/helpers/invoke-lambda.js
@@ -1,0 +1,31 @@
+const Lab = require('@hapi/lab')
+const lab = exports.lab = Lab.script()
+const Code = require('@hapi/code')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+const mocks = {
+  invokeAsync: sinon.stub()
+}
+
+const invokeLambda = proxyquire('../../../lib/helpers/invoke-lambda', {
+  'aws-sdk': {
+    Lambda: function Lambda () {
+      this.invokeAsync = mocks.invokeAsync
+    }
+  }
+})
+
+lab.experiment('invokeLambda', () => {
+  lab.test('it invokesAsync the function passing the payload as its InvokeArgs', () => {
+    mocks.invokeAsync.returns({ promise: async () => {} })
+
+    invokeLambda('some-function', { foo: 'bar' })
+
+    Code.expect(mocks.invokeAsync.getCalls().length).to.equal(1)
+    Code.expect(mocks.invokeAsync.getCalls()[0].args).to.equal([{
+      FunctionName: 'some-function',
+      InvokeArgs: '{"foo":"bar"}'
+    }])
+  })
+})


### PR DESCRIPTION
updates imtd lambda to only process the 500 rloi stations per invocation. The lambda will continuously invoke itself until all stations have been processed.

Note: this will require the application role to be updated with:
permission: `lambda:invokeFunction`
on resource: `arn:aws:lambda:*:${aws-account-id}:function:${stage}ldnlfw-*`