### PR TITLE
FSR-1429 | update to readme

### DIFF
--- a/lib/models/station.js
+++ b/lib/models/station.js
@@ -86,9 +86,10 @@ module.exports = {
     await pool.query('deleteStations')
 
     // batch up the database inserts as struggles with > 1500 records
-    const stationsFactor = Math.floor(dbStations.length / 500)
+    const batchSize = 500
+    const stationsFactor = Math.floor(dbStations.length / batchSize)
     for (let i = 0; i <= stationsFactor; i++) {
-      const batch = dbStations.slice(i * 500, (i * 500) + 500)
+      const batch = dbStations.slice(i * batchSize, (i * batchSize) + batchSize)
       await pool.query('insertStations', batch)
     }
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/DEFRA/flood-data.svg?branch=master)](https://travis-ci.com/DEFRA/flood-data)[![Maintainability](https://api.codeclimate.com/v1/badges/f36df721e8bfd20f2f0b/maintainability)](https://codeclimate.com/github/DEFRA/flood-data/maintainability)[![Test Coverage](https://api.codeclimate.com/v1/badges/f36df721e8bfd20f2f0b/test_coverage)](https://codeclimate.com/github/DEFRA/flood-data/test_coverage)
+![CI](https://github.com/DEFRA/flood-data/actions/workflows/ci.yml/badge.svg)[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_flood-data&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_flood-data)[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_flood-data&metric=coverage)](https://sonarcloud.io/summary/new_code?id=DEFRA_flood-data)
 
 # flood-data
 
@@ -48,5 +48,57 @@ This is installed using terraforms/terragrunt which is managed by WebOps
 ## Unit tests and linting
 `npm run pre-deployment-test`
 
-## Feature testing (integration)
-`npm run post-deployment-test`
+## 🔧 Configuration
+
+Since migrating from Serverless to Terraform for deploying Lambdas, the configuration for this service is now split between two sources: **GitLab** and **AWS Secrets Manager**. This structure ensures better separation of concerns and secure handling of sensitive data.
+
+### GitLab-Managed Environment Variables
+
+Configuration values related to infrastructure and deployment context are maintained in GitLab under [`lfwconfig`](https://gitlab-dev.aws-int.defra.cloud/flood/lfwconfig/-/tree/master/lfw-data):
+
+```bash
+export LFW_DATA_DB_CONNECTION=
+export LFW_DATA_TARGET_ENV_NAME=
+export LFW_DATA_SERVICE_CODE=
+export LFW_DATA_TARGET_REGION=
+export LFW_DATA_SLS_BUCKET=
+export LFW_DATA_SLS_BUCKET_ARN=
+export LFW_DATA_SLS_LAMBA_ROLE=
+export LFW_DATA_VPN_SECURITY_GROUP=
+export LFW_DATA_SUBNET_1=
+export LFW_DATA_SUBNET_2=
+```
+
+These values are version-controlled and environment-specific.
+
+### AWS Secrets Manager
+
+Sensitive or shared configuration values are stored securely in AWS Secrets Manager. These are managed by the **WebOps** team and can only be changed through them:
+
+```bash
+export LFW_DATA_FWIS_API_URL=
+export LFW_DATA_FWIS_API_KEY=
+```
+
+If you need updates to these secrets, please contact WebOps.
+
+### Terraform-Managed Scheduled Tasks
+
+Cron configurations (e.g., thresholds, data syncs) are managed per environment via Terraform:
+
+```bash
+export LFW_DATA_IMTD_THRESHOLD_SCHEDULE=
+export LFW_DATA_DTS_SCHEDULE=
+export LFW_DATA_FWIS_SCHEDULE=
+```
+
+These are defined in the Terraform modules and should be updated through the infrastructure as code process.
+
+### IMTD API Configuration
+
+All environments use the IMTD test API **except Pre and Prod**, which use the **public API endpoint**. This allows automated tests to run safely without affecting production data.
+
+```bash
+export imtd-api-url=
+```
+


### PR DESCRIPTION
This PR adds a new Configuration section to the README to reflect how things are set up now that we’re using Terraform instead of Serverless. It explains where config values live and who manages what.


Overview of the config split between GitLab and AWS Secrets Manager

List of environment variables for each location

Info on Terraform-managed cron schedules

Notes on IMTD API usage across environments


Anything in AWS Secrets needs to go through WebOps

Cron schedules are defined in Terraform per env

IMTD API points to the test API in most envs except Pre/Prod